### PR TITLE
Add maven exec goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,14 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.2.1</version>
+				<configuration>
+					<mainClass>com.fikky.FikkyApplication</mainClass>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
# Changelog
Added mvn exec goal to mvn pom.

# How to
From command line enter and run `mvn exec:java`. This will start up the spring server via executing the pom `exec-maven-plugin` which has the main class set to the package name. 

# NOTE 
**It is only an extra feature for development that is not necessary for the main product. Merge if you would like this feature for development otherwise this can stay local.**